### PR TITLE
Set min release age for picons

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,7 @@
     {
       "matchDatasources": ["github-releases"],
       "automerge": false,
+      "minimumReleaseAge": "1 day",
       "versioning": "loose"
     },
     {


### PR DESCRIPTION
# Proposed Changes
Picons packages appear after an hour or so on the release. Setting the `minimumReleaseAge` stops the renovate bot to directly create a PR (which might fail the build in case the packages are not available).
