### PR TITLE
Remove fallback to build latest TVHeadend commit

### DIFF
--- a/tvheadend/Dockerfile
+++ b/tvheadend/Dockerfile
@@ -65,10 +65,6 @@ RUN \
 
 RUN \
     echo "**** compile tvheadend ****" && \
-    if [ -z ${TVHEADEND_COMMIT+x} ]; then \
-    TVHEADEND_COMMIT=$(curl -sX GET https://api.github.com/repos/tvheadend/tvheadend/commits/master \
-    | jq -r '. | .sha'); \
-    fi && \
     mkdir -p \
     /tmp/tvheadend && \
     git clone https://github.com/tvheadend/tvheadend.git /tmp/tvheadend && \


### PR DESCRIPTION
# Proposed Changes

Remove the fallback logic that would build the latest TVHeadend commit in case the ARG is not set - which should never occur, as we pin to a specific commit in the Dockerfile. TVHeadend commits are bumped via Renovate Bot.
