### PR TITLE
Define regex versioning for picons releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
       "matchDatasources": ["github-releases"],
       "automerge": false,
       "minimumReleaseAge": "1 day",
-      "versioning": "loose"
+      "versioning": "regex:^(?<minor>\\d+\\-\\d+\\-\\d+)(\\-\\-(?<patch>\\d+\\-\\d+\\-\\d+))$"
     },
     {
       "matchDatasources": ["repology"],


### PR DESCRIPTION
# Proposed Changes
Define regex versioning for picons releases to match date part as the "minor" version and the time part as "patch". Picons don't really have a major, minor, patch version scheme, hence rating everything as a "minor" version bump seems more appropriate.
