### PR TITLE
NGINX security enhancements

### DIFF
--- a/tvheadend/config.yaml
+++ b/tvheadend/config.yaml
@@ -6,7 +6,6 @@ description: TV streaming server and recorder.
 url: "https://github.com/dfigus/addon-tvheadend"
 ingress: true
 ingress_stream: true
-ingress_port: 80
 init: false
 panel_icon: mdi:television
 arch:

--- a/tvheadend/rootfs/etc/nginx/http.d/default.conf
+++ b/tvheadend/rootfs/etc/nginx/http.d/default.conf
@@ -3,7 +3,9 @@
 
 server {
         listen 80 default_server;
-        listen [::]:80 default_server;
+#        listen [::]:80 default_server;
+        allow   172.30.32.2;
+        deny    all;
 
         location / {
             proxy_pass http://localhost:9981<ingress_path>/;
@@ -13,6 +15,8 @@ server {
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+
+
         }
 
 }

--- a/tvheadend/rootfs/etc/nginx/http.d/default.conf
+++ b/tvheadend/rootfs/etc/nginx/http.d/default.conf
@@ -2,20 +2,19 @@
 # <ingress_path>
 
 server {
-        listen 80 default_server;
+        listen 8099 default_server;
 #        listen [::]:80 default_server;
         allow   172.30.32.2;
         deny    all;
 
         location / {
             proxy_pass http://localhost:9981<ingress_path>/;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $remote_addr;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-
+            proxy_http_version                  1.1;
+            proxy_set_header Host               $host;
+            proxy_set_header X-Real-IP          $remote_addr;
+            proxy_set_header X-Forwarded-For    $remote_addr;
+            proxy_set_header Upgrade            $http_upgrade;
+            proxy_set_header Connection         $connection_upgrade;
 
         }
 

--- a/tvheadend/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/tvheadend/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -7,4 +7,4 @@
 
 bashio::log.info "Starting nginx..."
 
-nginx -g "daemon off;"
+nginx -g "daemon off;error_log /dev/stdout info;"


### PR DESCRIPTION
# Proposed Changes

- NGINX only allowing inbound connections from HAOS IPv4 address `172.30.32.2` as proposed [here](https://developers.home-assistant.io/docs/add-ons/presentation#ingress)
- NGINX no longer listening on IPv6
- NGINX using the default ingress port `8099`
- NGINX error log redirected to stdout