### PR TITLE
Rework port configs

### DIFF
--- a/tvheadend/config.yaml
+++ b/tvheadend/config.yaml
@@ -20,12 +20,6 @@ devices:
   - /dev/dri
   - /dev/vcsm-cma
   - /dev/vchiq
-ports:
-  9981/tcp: 9981
-  9982/tcp: 9982
-ports_description:
-  9981/tcp: TVH Web Interface
-  9982/tcp: TVH HTSP
 map:
   - addon_config:rw
   - share:rw

--- a/tvheadend/config.yaml
+++ b/tvheadend/config.yaml
@@ -5,6 +5,7 @@ slug: tvheadend
 description: TV streaming server and recorder.
 url: "https://github.com/dfigus/addon-tvheadend"
 ingress: true
+ingress_port: 0
 ingress_stream: true
 init: false
 panel_icon: mdi:television

--- a/tvheadend/rootfs/etc/cont-init.d/nginx.sh
+++ b/tvheadend/rootfs/etc/cont-init.d/nginx.sh
@@ -4,9 +4,15 @@
 # Configures NGINX for use with the NGINX Proxy Manager
 # ==============================================================================
 declare ingress_path
+declare ingress_port
 
 ingress_path=$(bashio::addon.ingress_entry)
+# Get assigned Ingress port
+ingress_port=$(bashio::addon.ingress_port)
+
 bashio::log.info "Ingress path used for nginx:  ${ingress_path}"
 
 # replace the placeholder with the actual ingress path in the nginx.conf
 sed -i "s|<ingress_path>|$ingress_path|g" /etc/nginx/http.d/default.conf
+
+sed -i "s|<ingress_port>|$ingress_port|g" /etc/nginx/http.d/default.conf

--- a/tvheadend/rootfs/etc/nginx/http.d/default.conf
+++ b/tvheadend/rootfs/etc/nginx/http.d/default.conf
@@ -1,9 +1,10 @@
 # proxy pass home assistant ingress to tvheadend with ingress path
 # <ingress_path>
+# listen on assigned ingress port
+# <ingress_port>
 
 server {
-        listen 8099 default_server;
-#        listen [::]:80 default_server;
+        listen <ingress_port> default_server;
         allow   172.30.32.2;
         deny    all;
 


### PR DESCRIPTION
# Proposed Changes

- Remove the port configuration from the addon-on as it anyhow does not work right now as we use host network (a proper host port configuration might be added in the future, but ports 9981 and 9982 are pretty exotic and likely not to clash with HA)
- Use a randomly assigned addon ingress port for nginx (default is 8099 and more likely to clash)