### PR TITLE
Add usb and video direct access

### DIFF
--- a/tvheadend/config.yaml
+++ b/tvheadend/config.yaml
@@ -16,6 +16,8 @@ arch:
   - armv7
   - i386
 host_network: true
+video: true
+usb: true
 devices:
   - /dev/dvb/
   - /dev/dvb/adapter0/demux0


### PR DESCRIPTION
# Proposed Changes

- USB access to trigger USB reset for buggy USB tuners 
- Video access might be required to enable hw encoding

## Related Issues

#141 