### PR TITLE
Add dvb linux firmwares

### DIFF
--- a/tvheadend/Dockerfile
+++ b/tvheadend/Dockerfile
@@ -208,6 +208,7 @@ RUN \
     py3-pip=23.3.1-r0 \
     libxslt=1.1.39-r0 \
     nginx=1.24.0-r15 \
+    linux-firmware-other=20240115-r0 \
     && pip3 install \
     --no-cache-dir \
     --prefer-binary \


### PR DESCRIPTION
# Proposed Changes

Add additional linux firmwares via Alpine package [linux-firmware-other](https://pkgs.alpinelinux.org/package/v3.19/main/aarch64/linux-firmware-other). This package also includes the DVB firmware dvb-fe-xc5000-1.6.114.fw mentioned in #109. 

Proper solution would be to include this in HA OS which seems to be possible via buildroot config `BR2_PACKAGE_LINUX_FIRMWARE_XCx000`, see buildroot config [here](https://github.com/buildroot/buildroot/blob/master/package/linux-firmware/Config.in#L582C8-L582C41) and linux firmware repo [here](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tree/). This would require a PR to HA OS.

## Related Issues
This might fix/mitigate #109.
