### PR TITLE
Add udev to addon

### DIFF
--- a/tvheadend/config.yaml
+++ b/tvheadend/config.yaml
@@ -18,6 +18,7 @@ arch:
 host_network: true
 video: true
 usb: true
+udev: true
 devices:
   - /dev/dvb/
   - /dev/dvb/adapter0/demux0


### PR DESCRIPTION
# Proposed Changes

This should give a better output of `lsusb` with proper device description