### PR TITLE
Add firmware symlink to /share/firmware for additional firmware

### DIFF
--- a/tvheadend/rootfs/lib/firmware/updates
+++ b/tvheadend/rootfs/lib/firmware/updates
@@ -1,0 +1,1 @@
+/share/firmware


### PR DESCRIPTION
# Proposed Changes

Add symlink /lib/firmware/updates to point to /share/firmware to allow drop-in of custom firmware.

## Related Issues
#109