### PR TITLE
Use IPv4 Address in NGINX proxy pass

### DIFF
--- a/tvheadend/rootfs/etc/nginx/http.d/default.conf
+++ b/tvheadend/rootfs/etc/nginx/http.d/default.conf
@@ -9,7 +9,7 @@ server {
         deny    all;
 
         location / {
-            proxy_pass http://localhost:9981<ingress_path>/;
+            proxy_pass http://127.0.0.1:9981<ingress_path>/;
             proxy_http_version                  1.1;
             proxy_set_header Host               $host;
             proxy_set_header X-Real-IP          $remote_addr;


### PR DESCRIPTION
# Proposed Changes
Avoid that `localhost` is resolved to IPv6 address in NGINX proxy pass by using `127.0.0.1` instead of `localhost`. This should solve the errors 
```
connect() failed (111: Connection refused) while connecting to upstream
```
as TVHeadend is not listening on IPv6.

## Related Issues

- #174 
- #175 
