### PR TITLE
Renovate Workaround for Repology Server Overload

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "configMigration": true,
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "extends": ["workarounds:reduceRepologyServerLoad"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
# Proposed Changes
This should fix 409 Too Many Requests