### PR TITLE
Update README with supported architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
 ![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -117,9 +115,7 @@ SOFTWARE.
 [releases]: https://github.com/dfigus/addon-tvheadend/releases
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [original-repository]: https://github.com/GauthamVarmaK/addon-tvheadend
 [commits-shield]: https://img.shields.io/github/commit-activity/y/dfigus/addon-tvheadend.svg
 [commits]: https://github.com/dfigus/addon-tvheadend/commits/main


### PR DESCRIPTION
# Proposed Changes

Update README with supported architectures. Removing i386 and armhf due to missing dotnet8 support which is required for WebGrab+Plus.