### PR TITLE
Fix Race Condition in Config Folder Creation

### DIFF
--- a/tvheadend/rootfs/etc/s6-overlay/s6-rc.d/init-comskip/run
+++ b/tvheadend/rootfs/etc/s6-overlay/s6-rc.d/init-comskip/run
@@ -11,7 +11,7 @@ comskip_ini_content=$(bashio::config 'comskip_ini')
 
 if ! bashio::fs.directory_exists '/config/tvheadend/comskip'; then
     bashio::log.info "Creating comskip ini directory at /config/tvheadend/comskip"
-    mkdir -p /config/tvheadend/comskip
+    mkdir /config/tvheadend/comskip
 fi
 
 bashio::log.info "Updating comskip.ini"

--- a/tvheadend/rootfs/etc/s6-overlay/s6-rc.d/init-wg++/run
+++ b/tvheadend/rootfs/etc/s6-overlay/s6-rc.d/init-wg++/run
@@ -15,7 +15,7 @@ bashio::log.info "Init WG++..."
 # create WG++ guide folder in addon config folder
 if ! bashio::fs.directory_exists "/config/tvheadend/wg++"; then
   bashio::log.info "Creating WG++ folder in config folder..."
-  mkdir -p /config/tvheadend/wg++
+  mkdir /config/tvheadend/wg++
 fi
 
 expectedParentDir="/wg/.wg++/siteini.pack"


### PR DESCRIPTION
# Proposed Changes
Make sure that only `init-tvheadend` is creating the config folder and that it is started before other services that depend on it. Otherwise the `--firstrun` of TVHeadend might not be called at all which creates proper initial ACL entries. Of those ACLs are not there, it will result in a TVHeadend instance that nobody can logon (and resulting in 403 errors).

## Related Issues

#329 
