### PR TITLE
Rollback to Alpine 3.21

### DIFF
--- a/tvheadend/Dockerfile
+++ b/tvheadend/Dockerfile
@@ -169,16 +169,16 @@ COPY requirements.txt /tmp/
 RUN \
     apk update \
     && apk add --no-cache --virtual .build-deps \
-    musl-dev=1.2.5-r10 \
-    gcc=14.2.0-r6 \
-    g++=14.2.0-r6 \
-    libxml2-dev=2.13.8-r0 \
-    libxslt-dev=1.1.43-r3 \
+    musl-dev=1.2.5-r9 \
+    gcc=14.2.0-r4 \
+    g++=14.2.0-r4 \
+    libxml2-dev=2.13.4-r6 \
+    libxslt-dev=1.1.42-r2 \
     python3-dev=3.12.11-r0 \
     && apk add --no-cache \
     bsd-compat-headers=0.7.2-r6 \
     ffmpeg4=4.4.5-r1 \
-    ffmpeg=6.1.2-r2	\
+    ffmpeg=6.1.2-r1	\
     ffmpeg4-libavcodec=4.4.5-r1 \
     ffmpeg4-libavdevice=4.4.5-r1 \
     ffmpeg4-libavfilter=4.4.5-r1 \
@@ -189,30 +189,30 @@ RUN \
     ffmpeg4-libswscale=4.4.5-r1 \
     gnu-libiconv=1.17-r2 \
     libdvbcsa=1.1.0-r1 \
-    libhdhomerun-libs=20231109-r0 \
+    libhdhomerun-libs=20200225-r1 \
     libva=2.22.0-r1 \
     libvpx=1.15.0-r0 \
-    libxml2=2.13.8-r0 \
-    libxslt=1.1.43-r3 \
-    linux-headers=6.14.2-r0 \
+    libxml2=2.13.4-r6 \
+    libxslt=1.1.42-r2 \
+    linux-headers=6.6-r1 \
     opus=1.5.2-r1	 \
-    pcre2=10.43-r1	 \
-    perl=5.40.2-r0	 \
+    pcre2=10.43-r0	 \
+    perl=5.40.1-r1	 \
     perl-datetime-format-strptime=1.79-r1 \
     perl-json=4.10-r1 \
     perl-json-xs=4.03-r5 \
     py3-requests=2.32.4-r0 \
     python3=3.12.11-r0 \
-    uriparser=0.9.8-r1 \
+    uriparser=0.9.8-r0 \
     x264=0.164.3108-r0 \
     x265=3.6-r0 \
     xmltv=1.3.0-r1 \
     zlib=1.3.1-r2 \
-    py3-pip=25.1.1-r0 \
-    libxslt=1.1.43-r3 \
-    nginx=1.28.0-r3 \
-    linux-firmware-other=20250509-r0 \
-    dotnet8-runtime=8.0.17-r0 \
+    py3-pip=24.3.1-r0 \
+    libxslt=1.1.42-r2 \
+    nginx=1.26.3-r0 \
+    linux-firmware-other=20241210-r0 \
+    dotnet8-runtime=8.0.16-r0 \
     xmlstarlet=1.6.1-r2 \
     && pip3 install \
     --no-cache-dir \

--- a/tvheadend/build.yaml
+++ b/tvheadend/build.yaml
@@ -1,5 +1,5 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:18.0.3
-  amd64: ghcr.io/hassio-addons/base/amd64:18.0.3
-  armv7: ghcr.io/hassio-addons/base/armv7:18.0.3
+  aarch64: ghcr.io/hassio-addons/base/aarch64:17.2.5
+  amd64: ghcr.io/hassio-addons/base/amd64:17.2.5
+  armv7: ghcr.io/hassio-addons/base/armv7:17.2.5


### PR DESCRIPTION
# Proposed Changes

Rollback to Alpine 3.21 to fix startup crash

## Related Issues

#440 